### PR TITLE
Fix correct output for day instead of month during post list

### DIFF
--- a/layouts/partials/post-list.html
+++ b/layouts/partials/post-list.html
@@ -9,7 +9,7 @@
 			</a>
 			</h1>
 			<p class="meta">
-				{{ .Date.Format "January 1, 2006" }} &middot; {{ .ReadingTime }} {{ .Site.Data.l10n.readingTime }}
+				{{ .Date.Format "January 2, 2006" }} &middot; {{ .ReadingTime }} {{ .Site.Data.l10n.readingTime }}
 			</p>
 		</header>
 		<div class="excerpt">


### PR DESCRIPTION
In the post list view, the date format parameter is wrond and will output the month twice (once as word, once as number).
To output the day you have to choose the number 2 and not 1 (that stand for Jan) according the Golang time / date format rules.
See https://golang.org/pkg/time/#pkg-constants
