### PR TITLE
Add highlight JS

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,4 +26,8 @@
 
 	{{ "<!-- Google Fonts -->" | safeHTML }}
 	<link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,700italic,400italic" rel="stylesheet" type="text/css">
+
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+  <script>hljs.initHighlightingOnLoad();</script>
 </head>


### PR DESCRIPTION
I felt code was hard to read with the default `<pre>`.

If you feel highlight JS is on your roadmap and works with your theme, it'd be dope if you added it. Let me know!
