### PR TITLE
Removing deprecated template variables

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="site-footer">
-	<p class="text">&copy; {{ .Now.Format "2006" }} - {{ .Site.Params.copyright | markdownify }}</p>
+	<p class="text">&copy; {{ now.Format "2006" }} - {{ .Site.Params.copyright | markdownify }}</p>
 </footer>
 
 {{ template "_internal/google_analytics.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,9 +16,9 @@
 	<link rel="shortcut icon" href="{{ .Site.BaseURL }}favicon.ico" type="image/x-icon">
 
 	{{ "<!-- RSS -->" | safeHTML }}
-	{{ if .RSSlink -}}
-	  	<link href="{{ .RSSlink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-	  	<link href="{{ .RSSlink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+	{{ if .RSSLink -}}
+	  	<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+	  	<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
 	{{- end }}
 
 	{{ "<!-- Font Awesome -->" | safeHTML }}


### PR DESCRIPTION
Love this theme, but Hugo 0.19 complains about some variables being deprecated.
With these changes it builds without wanrings on my machine.

* Changed “.RSSlink” to “.RSSLink”
* Changed “.Now” to “now”