### PR TITLE
Fix if condition for headerText

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,7 +5,7 @@
 		<div class="content">
 			<div class="home">
 
-				{{ if isset .Site.Params "headerText" }}
+				{{ if .Site.Params.headerText }}
 				<div class="call-out" style="background-image: url('{{ .Site.BaseURL }}/img/{{ .Site.Params.headerImage }}')">
 					{{ .Site.Params.headerText | markdownify }}
 				</div>


### PR DESCRIPTION
In the hugo version `Hugo Static Site Generator v0.19 darwin/amd64 BuildDate: 2017-02-27T11:21:29+01:00` the header text will not be shown.

This PR fixes it.