### PR TITLE
Close <article>-tag in single view

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -12,11 +12,12 @@
 		</header>
 	{{- end }}
 
-	<section class="post-content">
-		{{ .Content }}
+		<section class="post-content">
+			{{ .Content }}
 
-		{{ if (not (eq .Site.DisqusShortname "")) | and (not .Params.disableComments) }}
-			{{ template "_internal/disqus.html" . }}
-		{{ end }}
-	</section>
+			{{ if (not (eq .Site.DisqusShortname "")) | and (not .Params.disableComments) }}
+				{{ template "_internal/disqus.html" . }}
+			{{ end }}
+		</section>
+	</article>
 {{- end }}


### PR DESCRIPTION
The `<article>`-HTML-Tag is not closed in the single view of a post