### PR TITLE
Wrap Google Analytics into an own partial to be able to overwrite it

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,4 +2,4 @@
 	<p class="text">&copy; {{ now.Format "2006" }} - {{ .Site.Params.copyright | markdownify }}</p>
 </footer>
 
-{{ template "_internal/google_analytics.html" . }}
+{{ partial "tracking.html" . }}

--- a/layouts/partials/tracking.html
+++ b/layouts/partials/tracking.html
@@ -1,0 +1,1 @@
+{{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
By wrapping the internal hugo template, the site is able to overwrite the template.
This can be useful especially in germany when you want  to use the

```js
ga('set', 'anonymizeIp', true);
```

feature.