### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/icons.html
+++ b/layouts/partials/icons.html
@@ -24,7 +24,7 @@
 
 {{ with .Site.Params.social.behance -}}
 <li class="icon">
-	<a href="https://www.behance.net/{{ $.Site.Params.social.behance }}" title="{{ $.Site.Data.l10n.behance }}">
+	<a href="https://www.behance.net/{{ $.Site.Params.social.behance }}" rel="me" title="{{ $.Site.Data.l10n.behance }}">
 		<i class="fab fa-fw fa-behance"></i>
 	</a>
 </li>
@@ -32,7 +32,7 @@
 
 {{ with .Site.Params.social.bitbucket -}}
 <li class="icon">
-	<a href="https://bitbucket.org/{{ $.Site.Params.social.bitbucket }}" title="{{ $.Site.Data.l10n.bitbucket }}">
+	<a href="https://bitbucket.org/{{ $.Site.Params.social.bitbucket }}" rel="me" title="{{ $.Site.Data.l10n.bitbucket }}">
 		<i class="fab fa-fw fa-bitbucket"></i>
 	</a>
 </li>
@@ -40,7 +40,7 @@
 
 {{ with .Site.Params.social.dribbble -}}
 <li class="icon">
-	<a href="https://dribbble.com/{{ $.Site.Params.social.dribbble }}" title="{{ $.Site.Data.l10n.dribbble }}">
+	<a href="https://dribbble.com/{{ $.Site.Params.social.dribbble }}" rel="me" title="{{ $.Site.Data.l10n.dribbble }}">
 		<i class="fab fa-fw fa-dribbble"></i>
 	</a>
 </li>
@@ -48,7 +48,7 @@
 
 {{ with .Site.Params.social.facebook -}}
 <li class="icon">
-	<a href="https://www.facebook.com/{{ $.Site.Params.social.facebook }}" title="{{ $.Site.Data.l10n.facebook }}">
+	<a href="https://www.facebook.com/{{ $.Site.Params.social.facebook }}" rel="me" title="{{ $.Site.Data.l10n.facebook }}">
 		<i class="fab fa-fw fa-facebook"></i>
 	</a>
 </li>
@@ -56,7 +56,7 @@
 
 {{ with .Site.Params.social.flickr -}}
 <li class="icon">
-	<a href="https://www.flickr.com/photos/{{ $.Site.Params.social.flickr }}" title="{{ $.Site.Data.l10n.flickr }}">
+	<a href="https://www.flickr.com/photos/{{ $.Site.Params.social.flickr }}" rel="me" title="{{ $.Site.Data.l10n.flickr }}">
 		<i class="fab fa-fw fa-flickr"></i>
 	</a>
 </li>
@@ -64,7 +64,7 @@
 
 {{ with .Site.Params.social.github -}}
 <li class="icon">
-	<a href="https://github.com/{{ $.Site.Params.social.github }}" title="{{ $.Site.Data.l10n.github }}">
+	<a href="https://github.com/{{ $.Site.Params.social.github }}" rel="me" title="{{ $.Site.Data.l10n.github }}">
 		<i class="fab fa-fw fa-github"></i>
 	</a>
 </li>
@@ -72,7 +72,7 @@
 
 {{ with .Site.Params.social.googleplus -}}
 <li class="icon">
-	<a href="https://plus.google.com/{{ $.Site.Params.social.googleplus }}" title="{{ $.Site.Data.l10n.googleplus }}">
+	<a href="https://plus.google.com/{{ $.Site.Params.social.googleplus }}" rel="me" title="{{ $.Site.Data.l10n.googleplus }}">
 		<i class="fab fa-fw fa-google-plus"></i>
 	</a>
 </li>
@@ -80,7 +80,7 @@
 
 {{ with .Site.Params.social.instagram -}}
 <li class="icon">
-	<a href="https://instagram.com/{{ $.Site.Params.social.instagram }}" title="{{ $.Site.Data.l10n.instagram }}">
+	<a href="https://instagram.com/{{ $.Site.Params.social.instagram }}" rel="me" title="{{ $.Site.Data.l10n.instagram }}">
 		<i class="fab fa-fw fa-instagram"></i>
 	</a>
 </li>
@@ -88,7 +88,7 @@
 
 {{ with .Site.Params.social.linkedin -}}
 <li class="icon">
-	<a href="https://www.linkedin.com/in/{{ $.Site.Params.social.linkedin }}" title="{{ $.Site.Data.l10n.linkedin }}">
+	<a href="https://www.linkedin.com/in/{{ $.Site.Params.social.linkedin }}" rel="me" title="{{ $.Site.Data.l10n.linkedin }}">
 		<i class="fab fa-fw fa-linkedin"></i>
 	</a>
 </li>
@@ -96,7 +96,7 @@
 
 {{ with .Site.Params.social.pinterest -}}
 <li class="icon">
-	<a href="https://www.pinterest.com/{{ $.Site.Params.social.pinterest }}" title="{{ $.Site.Data.l10n.pinterest }}">
+	<a href="https://www.pinterest.com/{{ $.Site.Params.social.pinterest }}" rel="me" title="{{ $.Site.Data.l10n.pinterest }}">
 		<i class="fab fa-fw fa-pinterest"></i>
 	</a>
 </li>
@@ -104,7 +104,7 @@
 
 {{ with .Site.Params.social.reddit -}}
 <li class="icon">
-	<a href="https://www.reddit.com/user/{{ $.Site.Params.social.reddit }}" title="{{ $.Site.Data.l10n.reddit }}">
+	<a href="https://www.reddit.com/user/{{ $.Site.Params.social.reddit }}" rel="me" title="{{ $.Site.Data.l10n.reddit }}">
 		<i class="fab fa-fw fa-reddit"></i>
 	</a>
 </li>
@@ -112,7 +112,7 @@
 
 {{ with .Site.Params.social.soundcloud -}}
 <li class="icon">
-	<a href="https://soundcloud.com/{{ $.Site.Params.social.soundcloud }}" title="{{ $.Site.Data.l10n.soundcloud }}">
+	<a href="https://soundcloud.com/{{ $.Site.Params.social.soundcloud }}" rel="me" title="{{ $.Site.Data.l10n.soundcloud }}">
 		<i class="fab fa-fw fa-soundcloud"></i>
 	</a>
 </li>
@@ -120,7 +120,7 @@
 
 {{ with .Site.Params.social.stackexchange -}}
 <li class="icon">
-	<a href="{{ $.Site.Params.social.stackexchange }}" title="{{ $.Site.Data.l10n.stackexchange }}">
+	<a href="{{ $.Site.Params.social.stackexchange }}" rel="me" title="{{ $.Site.Data.l10n.stackexchange }}">
 		<i class="fab fa-fw fa-stack-exchange"></i>
 	</a>
 </li>
@@ -128,7 +128,7 @@
 
 {{ with .Site.Params.social.steam -}}
 <li class="icon">
-	<a href="https://steamcommunity.com/id/{{ $.Site.Params.social.steam }}" title="{{ $.Site.Data.l10n.steam }}">
+	<a href="https://steamcommunity.com/id/{{ $.Site.Params.social.steam }}" rel="me" title="{{ $.Site.Data.l10n.steam }}">
 		<i class="fab fa-fw fa-steam"></i>
 	</a>
 </li>
@@ -136,7 +136,7 @@
 
 {{ with .Site.Params.social.tumblr -}}
 <li class="icon">
-	<a href="http://{{ $.Site.Params.social.tumblr }}.tumblr.com/" title="{{ $.Site.Data.l10n.tumblr }}">
+	<a href="http://{{ $.Site.Params.social.tumblr }}.tumblr.com/" rel="me" title="{{ $.Site.Data.l10n.tumblr }}">
 		<i class="fab fa-fw fa-tumblr"></i>
 	</a>
 </li>
@@ -144,7 +144,7 @@
 
 {{ with .Site.Params.social.twitter -}}
 <li class="icon">
-	<a href="https://twitter.com/{{ $.Site.Params.social.twitter }}" title="{{ $.Site.Data.l10n.twitter }}">
+	<a href="https://twitter.com/{{ $.Site.Params.social.twitter }}" rel="me" title="{{ $.Site.Data.l10n.twitter }}">
 		<i class="fab fa-fw fa-twitter"></i>
 	</a>
 </li>
@@ -152,7 +152,7 @@
 
 {{ with .Site.Params.social.wordpress -}}
 <li class="icon">
-	<a href="https://{{ $.Site.Params.social.wordpress }}.wordpress.com/" title="{{ $.Site.Data.l10n.wordpress }}">
+	<a href="https://{{ $.Site.Params.social.wordpress }}.wordpress.com/" rel="me" title="{{ $.Site.Data.l10n.wordpress }}">
 		<i class="fab fa-fw fa-wordpress"></i>
 	</a>
 </li>
@@ -160,7 +160,7 @@
 
 {{ with .Site.Params.social.youtube -}}
 <li class="icon">
-	<a href="https://www.youtube.com/user/{{ $.Site.Params.social.youtube }}" title="{{ $.Site.Data.l10n.youtube }}">
+	<a href="https://www.youtube.com/user/{{ $.Site.Params.social.youtube }}" rel="me" title="{{ $.Site.Data.l10n.youtube }}">
 		<i class="fab fa-fw fa-youtube"></i>
 	</a>
 </li>
@@ -168,7 +168,7 @@
 
 {{ with .Site.Params.social.trello -}}
 <li class="icon">
-	<a href="https://trello.com/{{ $.Site.Params.social.trello }}" title="{{ $.Site.Data.l10n.trello }}">
+	<a href="https://trello.com/{{ $.Site.Params.social.trello }}" rel="me" title="{{ $.Site.Data.l10n.trello }}">
 		<i class="fab fa-fw fa-trello"></i>
 	</a>
 </li>
@@ -176,7 +176,7 @@
 
 {{ with .Site.Params.social.gitlab -}}
 <li class="icon">
-	<a href="https://gitlab.com/{{ $.Site.Params.social.gitlab }}" title="{{ $.Site.Data.l10n.gitlab }}">
+	<a href="https://gitlab.com/{{ $.Site.Params.social.gitlab }}" rel="me" title="{{ $.Site.Data.l10n.gitlab }}">
 		<i class="fab fa-fw fa-gitlab"></i>
 	</a>
 </li>
@@ -184,7 +184,7 @@
 
 {{ with .Site.Params.social.meetup -}}
 <li class="icon">
-	<a href="https://meetup.com/{{ $.Site.Params.social.meetup }}" title="{{ $.Site.Data.l10n.meetup }}">
+	<a href="https://meetup.com/{{ $.Site.Params.social.meetup }}" rel="me" title="{{ $.Site.Data.l10n.meetup }}">
 		<i class="fab fa-fw fa-meetup"></i>
 	</a>
 </li>
@@ -192,7 +192,7 @@
 
 {{ with .Site.Params.social.speakerdeck -}}
 <li class="icon">
-	<a href="https://speakerdeck.com/{{ $.Site.Params.social.speakerdeck }}" title="{{ $.Site.Data.l10n.speakerdeck }}">
+	<a href="https://speakerdeck.com/{{ $.Site.Params.social.speakerdeck }}" rel="me" title="{{ $.Site.Data.l10n.speakerdeck }}">
 		<i class="fab fa-fw fa-speaker-deck"></i>
 	</a>
 </li>


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.