### PR TITLE
Added Open Graph support

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,6 +7,8 @@
 	{{ with .Site.Params.keywords }}<meta name="keywords" content="{{ . }}">{{ end }}
 	{{ .Hugo.Generator }}
 
+	{{ template "_internal/opengraph.html" . }}
+
 	{{ "<!-- CSS -->" | safeHTML }}
 	<link rel="stylesheet" href="{{ "css/main.css" | absURL }}">
 


### PR DESCRIPTION
This PR adds support for Open Graph. This is natively supported by Hugo. See https://gohugo.io/templates/internal/#configure-open-graph

Open Graph is used in social media previews like Facebook. See https://stackoverflow.com/questions/48044181/telegram-and-fb-link-preview