### PR TITLE
Fix "WARN [...] Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
 	{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 	{{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 	{{ with .Site.Params.keywords }}<meta name="keywords" content="{{ . }}">{{ end }}
-	{{ .Hugo.Generator }}
+	{{ hugo.Generator }}
 
 	{{ template "_internal/opengraph.html" . }}
 


### PR DESCRIPTION
When rendering the page, a warning  pops up:

```
WARN 2019/07/01 13:38:43 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
```

This is also mentioned in the official hugo documentation: https://gohugo.io/variables/hugo/

> Page’s .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
> For example: hugo.Generator.