### PR TITLE
Fix "WARN [...] Page's .RSSLink is deprecated [...] Use the Output Format's link"

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,10 +16,9 @@
 	<link rel="apple-touch-icon" href="{{ "apple-touch-icon.png" | absURL }}">
 	<link rel="shortcut icon" href="{{ "favicon.ico" | absURL }}" type="image/x-icon">
 
-	{{ if .RSSLink -}}
+	{{ with .OutputFormats.Get "rss" -}}
 	{{ "<!-- RSS -->" | safeHTML }}
-		<link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-		<link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
+	{{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
 	{{- end }}
 
 	{{ "<!-- Font Awesome -->" | safeHTML }}


### PR DESCRIPTION
When rendering the site an error occurs:

WARN 2019/07/02 12:11:16 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.

Related:
- https://github.com/gohugoio/hugo/issues/4427

Furthermore, the `rel="feed"` line will be removed, because I can't find a reference that this does exist at all (see https://www.w3schools.com/tags/att_link_rel.asp).

The new code will result in (e.g.):
```
<!-- RSS -->
<link href="http://localhost:1313/index.xml" rel="alternate" type="application/rss+xml" title="Andy Grunwald" />
```